### PR TITLE
#correct によるよみがな修正の際にひらがなが混在していても修正できるようにした

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [0.1.2] - 2021-10-09
+- add: #correct によるよみがな修正の際にひらがなが混在していても修正できるようにした [#7](https://github.com/yuriko1211/utanone/pull/7)
+
 ## [0.1.1] - 2021-09-29
 - fix: Gem install後に想定しているパスでrequire出来なかったため修正
 

--- a/lib/utanone/uta.rb
+++ b/lib/utanone/uta.rb
@@ -70,7 +70,7 @@ module Utanone
     private
 
     def parse_to_hash(str, ref_uta)
-      parsed_str_enum = natto.enum_parse(conversion_number(str))
+      parsed_str_enum = natto.enum_parse(convert_number(str))
 
       parsed_str_enum.each_with_object([]) do |result, array|
         next if result.is_eos?
@@ -91,7 +91,7 @@ module Utanone
       raise Utanone::ParseError
     end
 
-    def conversion_number(str)
+    def convert_number(str)
       # 半角数字を全角数字にしないと読みが取れないので変換する
       str.tr('0-9a-zA-Z', '０-９ａ-ｚＡ-Ｚ')
     end

--- a/lib/utanone/version.rb
+++ b/lib/utanone/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Utanone
-  VERSION = '0.1.1'
+  VERSION = '0.1.2'
 end

--- a/spec/uta_spec.rb
+++ b/spec/uta_spec.rb
@@ -148,6 +148,21 @@ RSpec.describe Utanone::Uta do
             { word: '灯', ruby: 'アカリ', lexical_category: '名詞' }
           ]
         end
+
+        context '修正するよみがなにひらがなとカタカナが混在している場合' do
+          let(:correct_yomigana) { 'ゴゼンよジノトモしび' }
+
+          it 'よみがなが修正された状態のUtaオブジェクトが返却されること' do
+            expect(subject.yomigana).to eq 'ゴゼンヨジノトモシビ'
+            expect(subject.parsed_morphemes).to eq [
+              { word: '午前', ruby: 'ゴゼン', lexical_category: '名詞' },
+              { word: '四', ruby: 'ヨ', lexical_category: '名詞' },
+              { word: '時', ruby: 'ジ', lexical_category: '名詞' },
+              { word: 'の', ruby: 'ノ', lexical_category: '助詞' },
+              { word: '灯', ruby: 'トモシビ', lexical_category: '名詞' }
+            ]
+          end
+        end
       end
 
       context '修正する形態素が連続している場合' do


### PR DESCRIPTION
#correct の引数に指定する `correct_yomigana` はカタカナを想定していました。
ひらがなを入力した場合はカタカナに変換し、よみがなは常にカタカナで 扱うように修正します。