### PR TITLE
MeCabで読みが取れなかった場合に表層形がひらがなorカタカナであれば表層系をカタカナにして返す

### DIFF
--- a/lib/utanone/uta.rb
+++ b/lib/utanone/uta.rb
@@ -79,16 +79,7 @@ module Utanone
         next if result.is_eos?
 
         morpheme = separated_element(result)
-
-        if ref_uta
-          # ref_utaとして参照するUtaオブジェクトが渡されている場合は読みを参照するUtaオブジェクトから取得する
-          ref_morpheme = ref_uta.parsed_morphemes.find { _1[:word] == morpheme[:word] }
-          morpheme[:ruby] = ref_morpheme[:ruby] if ref_morpheme
-        end
-
-        unless morpheme[:ruby]
-          morpheme[:ruby] = correct_ruby(morpheme[:ruby])
-        end
+        morpheme[:ruby] = correct_ruby(morpheme, ref_uta)
 
         array << morpheme
       end
@@ -124,10 +115,20 @@ module Utanone
       }
     end
 
-    def correct_ruby(ruby)
-      raise Utanone::ParseError unless HIRAGANA_AND_KATAKANA.match?(ruby)
+    def correct_ruby(morpheme, ref_uta)
+      if ref_uta
+        # ref_utaとして参照するUtaオブジェクトが渡されている場合は読みを参照するUtaオブジェクトから取得する
+        ref_morpheme = ref_uta.parsed_morphemes.find { _1[:word] == morpheme[:word] }
+        morpheme[:ruby] = ref_morpheme[:ruby] if ref_morpheme
+      end
 
-      convert_kana(ruby)
+      if morpheme[:ruby]
+        morpheme[:ruby]
+      else
+        raise Utanone::ParseError unless HIRAGANA_AND_KATAKANA.match?(morpheme[:word])
+
+        convert_kana(morpheme[:word])
+      end
     end
 
     def natto

--- a/lib/utanone/uta.rb
+++ b/lib/utanone/uta.rb
@@ -8,6 +8,7 @@ module Utanone
 
     EXCLUDING_COUNTING_RUBY_BY_TANKA = /ァ|ィ|ォ|ャ|ュ|ョ/
     EXCLUDING_COUNTING_LEXICAL_CATEGORIES = %w[記号].freeze
+    HIRAGANA_AND_KATAKANA = /\A[ぁ-んァ-ヶー－]+\z/
 
     def initialize(str, ref_uta = nil)
       @original_str = str
@@ -86,11 +87,7 @@ module Utanone
         end
 
         unless morpheme[:ruby]
-          if /\A[ぁ-んァ-ヶー－]+\z/.match?(morpheme[:word])
-            morpheme[:ruby] = convert_kana(morpheme[:word])
-          else
-            raise Utanone::ParseError
-          end
+          morpheme[:ruby] = correct_ruby(morpheme[:ruby])
         end
 
         array << morpheme
@@ -125,6 +122,12 @@ module Utanone
         ruby: ruby,
         lexical_category: lexical_category
       }
+    end
+
+    def correct_ruby(ruby)
+      raise Utanone::ParseError unless HIRAGANA_AND_KATAKANA.match?(ruby)
+
+      convert_kana(ruby)
     end
 
     def natto

--- a/lib/utanone/uta.rb
+++ b/lib/utanone/uta.rb
@@ -85,7 +85,13 @@ module Utanone
           morpheme[:ruby] = ref_morpheme[:ruby] if ref_morpheme
         end
 
-        raise Utanone::ParseError unless morpheme[:ruby]
+        unless morpheme[:ruby]
+          if /\A[ぁ-んァ-ヶー－]+\z/.match?(morpheme[:word])
+            morpheme[:ruby] = convert_kana(morpheme[:word])
+          else
+            raise Utanone::ParseError
+          end
+        end
 
         array << morpheme
       end


### PR DESCRIPTION
固有名詞の場合等で、読みが取れないケースが存在する。元々はUtanone::ParseErrorを発生させていたが、表層系がひらがなorカタカナであれば、カタカナに変換したうえで処理を続行することにした。

また、読みの補正を行う部分をメソッドに切り出した。